### PR TITLE
Memory window should not reset device registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SYMON - A 6502 System Simulator
 
 See the file COPYING for license.
 
-![Symon Simulator in Action] (http://www.loomcom.com/symon/screenshots/full.jpg)
+![Symon Simulator in Action](http://www.loomcom.com/symon/screenshots/full.jpg)
 
 ## 1.0 About
 
@@ -22,7 +22,7 @@ experimental 6545 CRTC.
 
 Symon has extensive unit tests to verify correctness, and fully passes
 Klaus Dormann's 6502 Functional Test Suite as of version 0.8.2
-(See [this thread on the 6502.org Forums] (http://forum.6502.org/viewtopic.php?f=2&t=2241)
+(See [this thread on the 6502.org Forums](http://forum.6502.org/viewtopic.php?f=2&t=2241)
 for more information about this functional test suite).
 
 Symon is under constant, active development. Feedback and patches
@@ -66,7 +66,7 @@ memory.
 
 ### 3.2 Serial Console and CPU Status
 
-![Serial Console] (http://www.loomcom.com/symon/screenshots/console.png)
+![Serial Console](http://www.loomcom.com/symon/screenshots/console.png)
 
 The main window of the simulator acts as the primary Input/Output
 system through a virtual serial terminal. The terminal is attached to
@@ -78,13 +78,13 @@ It also provides CPU status. Contents of the accumulator, index
 registers, processor status flags, disassembly of the instruction
 register, and stack pointer are all displayed.
 
-![Font Selection] (http://www.loomcom.com/symon/screenshots/font_selection.png)
+![Font Selection](http://www.loomcom.com/symon/screenshots/font_selection.png)
 
 The console supports font sizes from 10 to 20 points.
 
 ### 3.3 ROM Loading
 
-![ROM Loading] (http://www.loomcom.com/symon/screenshots/load_rom.png)
+![ROM Loading](http://www.loomcom.com/symon/screenshots/load_rom.png)
 
 Symon can load any appropriately sized ROM image. The Symon
 architecture expects as 16KB (16384 byte) ROM image, while the
@@ -95,32 +95,32 @@ address.
 
 ### 3.4 Memory Window
 
-![Memory Window] (http://www.loomcom.com/symon/screenshots/memory_window.png)
+![Memory Window](http://www.loomcom.com/symon/screenshots/memory_window.png)
 
 Memory contents can be viewed (and edited) one page at a time through the Memory Window.
 
 ### 3.5 Trace Log
 
-![Trace Log] (http://www.loomcom.com/symon/screenshots/trace_log.png)
+![Trace Log](http://www.loomcom.com/symon/screenshots/trace_log.png)
 
 The last 20,000 execution steps are disassembled and logged to the Trace Log
 Window.
 
 ### 3.6 Simulator Speeds
 
-![Speeds] (http://www.loomcom.com/symon/screenshots/simulator_menu.png)
+![Speeds](http://www.loomcom.com/symon/screenshots/simulator_menu.png)
 
 Simulated speeds may be set from 1MHz to 8MHz.
 
 ### 3.7 Breakpoints
 
-![Breakpoints] (http://www.loomcom.com/symon/screenshots/breakpoints.png)
+![Breakpoints](http://www.loomcom.com/symon/screenshots/breakpoints.png)
 
 Breakpoints can be set and removed through the Breakpoints window.
 
 ### 3.8 Experimental 6545 CRTC Video
 
-![Composite Video] (http://www.loomcom.com/symon/screenshots/video_window.png)
+![Composite Video](http://www.loomcom.com/symon/screenshots/video_window.png)
 
 This feature is highly experimental. It's possible to open a video window
 from the "View" menu.  This window simulates the output of a MOS 6545 CRT
@@ -158,9 +158,9 @@ between the simulated 6545 and a real 6545:
 
 For more information on the 6545 CRTC and its programming model, please see the following resources
 
-  - [CRTC 6545/6845 Information (André Fachat)] (http://6502.org/users/andre/hwinfo/crtc/index.html)
-  - [CRTC Operation (André Fachat)] (http://www.6502.org/users/andre/hwinfo/crtc/crtc.html)
-  - [MOS 6545 Datasheet (PDF)] (http://www.6502.org/users/andre/hwinfo/crtc/crtc.html)
+  - [CRTC 6545/6845 Information (André Fachat)](http://6502.org/users/andre/hwinfo/crtc/index.html)
+  - [CRTC Operation (André Fachat)](http://www.6502.org/users/andre/hwinfo/crtc/crtc.html)
+  - [MOS 6545 Datasheet (PDF)](http://www.6502.org/users/andre/hwinfo/crtc/crtc.html)
 
 
 #### 3.8.1 Example BASIC Program to test Video
@@ -338,10 +338,10 @@ Additional components used in this project are copyright their respective owners
 
 This project would not have been possible without the following resources:
 
-  - [Andrew Jacobs' 6502 Pages] (http://www.obelisk.demon.co.uk/6502/), for
+  - [Andrew Jacobs' 6502 Pages](http://www.obelisk.demon.co.uk/6502/), for
     wonderfully detailed information about the 6502
 
-  - [Neil Parker's "The 6502/65C02/65C816 Instruction Set Decoded"] (http://www.llx.com/~nparker/a2/opcodes.html),
+  - [Neil Parker's "The 6502/65C02/65C816 Instruction Set Decoded"](http://www.llx.com/~nparker/a2/opcodes.html),
     for information about how instructions are coded
 
 ## 9.0 Licensing

--- a/src/main/java/com/loomcom/symon/Bus.java
+++ b/src/main/java/com/loomcom/symon/Bus.java
@@ -168,12 +168,12 @@ public class Bus {
         return true;
     }
 
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         Device d = deviceAddressArray[address - this.startAddress];
         if (d != null) {
             MemoryRange range = d.getMemoryRange();
             int devAddr = address - range.startAddress();
-            return d.read(devAddr) & 0xff;
+            return d.read(devAddr, cpuAccess) & 0xff;
         }
 
         throw new MemoryAccessException("Bus read failed. No device at address " + String.format("$%04X", address));

--- a/src/main/java/com/loomcom/symon/Simulator.java
+++ b/src/main/java/com/loomcom/symon/Simulator.java
@@ -348,7 +348,7 @@ public class Simulator {
         // output ready.
         if (machine.getAcia() != null && machine.getAcia().hasTxChar()) {
             // This is thread-safe
-            console.print(Character.toString((char) machine.getAcia().txRead()));
+            console.print(Character.toString((char) machine.getAcia().txRead(true)));
             console.repaint();
         }
 

--- a/src/main/java/com/loomcom/symon/devices/Acia.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia.java
@@ -107,10 +107,12 @@ public abstract class Acia extends Device {
         return name + "@" + String.format("%04X", baseAddress);
     }
 
-    public synchronized int rxRead() {
-        lastRxRead = System.nanoTime();
-        overrun = false;
-        rxFull = false;
+    public synchronized int rxRead(boolean cpuAccess) {
+        if (cpuAccess) {
+            lastRxRead = System.nanoTime();
+            overrun = false;
+            rxFull = false;
+        }
         return rxChar;
     }
 
@@ -128,13 +130,14 @@ public abstract class Acia extends Device {
         rxChar = data;
     }
 
-    public synchronized int txRead() {
-        txEmpty = true;
+    public synchronized int txRead(boolean cpuAccess) {
+        if (cpuAccess) {
+          txEmpty = true;
 
-        if (transmitIrqEnabled) {
+          if (transmitIrqEnabled) {
             getBus().assertIrq();
+           }
         }
-
         return txChar;
     }
 

--- a/src/main/java/com/loomcom/symon/devices/Acia6551.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia6551.java
@@ -56,10 +56,10 @@ public class Acia6551 extends Acia {
     }
 
     @Override
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         switch (address) {
             case DATA_REG:
-                return rxRead();
+                return rxRead(cpuAccess);
             case STAT_REG:
                 return statusReg();
             case CMND_REG:

--- a/src/main/java/com/loomcom/symon/devices/Acia6850.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia6850.java
@@ -53,10 +53,10 @@ public class Acia6850 extends Acia {
     }
 
     @Override
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         switch (address) {
             case RX_REG:
-                return rxRead();
+                return rxRead(cpuAccess);
             case STAT_REG:
                 return statusReg();
 

--- a/src/main/java/com/loomcom/symon/devices/Crtc.java
+++ b/src/main/java/com/loomcom/symon/devices/Crtc.java
@@ -119,7 +119,7 @@ public class Crtc extends Device {
     }
 
     @Override
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         switch (address) {
             case REGISTER_RW:
                 switch (currentRegister) {
@@ -142,7 +142,7 @@ public class Crtc extends Device {
 
     public int getCharAtAddress(int address) throws MemoryAccessException {
         // TODO: Row/Column addressing
-        return memory.read(address);
+        return memory.read(address, false);
     }
 
     public int getHorizontalDisplayed() {

--- a/src/main/java/com/loomcom/symon/devices/Device.java
+++ b/src/main/java/com/loomcom/symon/devices/Device.java
@@ -72,7 +72,7 @@ public abstract class Device implements Comparable<Device> {
     /* Methods required to be implemented by inheriting classes. */
     public abstract void write(int address, int data) throws MemoryAccessException;
 
-    public abstract int read(int address) throws MemoryAccessException;
+    public abstract int read(int address, boolean cpuAccess) throws MemoryAccessException;
 
     public abstract String toString();
 

--- a/src/main/java/com/loomcom/symon/devices/Memory.java
+++ b/src/main/java/com/loomcom/symon/devices/Memory.java
@@ -94,7 +94,7 @@ public class Memory extends Device {
 
     }
 
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         return this.mem[address];
     }
 

--- a/src/main/java/com/loomcom/symon/devices/SdController.java
+++ b/src/main/java/com/loomcom/symon/devices/SdController.java
@@ -94,7 +94,7 @@ public class SdController extends Device {
     }
 
     @Override
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         switch (address) {
             case 0:
                 return readData();

--- a/src/main/java/com/loomcom/symon/devices/Via6522.java
+++ b/src/main/java/com/loomcom/symon/devices/Via6522.java
@@ -75,7 +75,7 @@ public class Via6522 extends Pia {
     }
 
     @Override
-    public int read(int address) throws MemoryAccessException {
+    public int read(int address, boolean cpuAccess) throws MemoryAccessException {
         Register[] registers = Register.values();
 
         if (address >= registers.length) {

--- a/src/main/java/com/loomcom/symon/ui/MemoryWindow.java
+++ b/src/main/java/com/loomcom/symon/ui/MemoryWindow.java
@@ -331,10 +331,10 @@ public class MemoryWindow extends JFrame implements ActionListener {
                     return Utils.wordToHex(fullAddress(row, 1));
                 } else if (column < 9) {
                     // Display hex value of the data
-                    return Utils.byteToHex(bus.read(fullAddress(row, column)));
+                    return Utils.byteToHex(bus.read(fullAddress(row, column), false));
                 } else {
                     // Display the ASCII equivalent (if printable)
-                    return Utils.byteToAscii(bus.read(fullAddress(row, column - 8)));
+                    return Utils.byteToAscii(bus.read(fullAddress(row, column - 8), false));
                 }
             } catch (MemoryAccessException ex) {
                 return "??";

--- a/src/test/java/com/loomcom/symon/AciaTest6850.java
+++ b/src/test/java/com/loomcom/symon/AciaTest6850.java
@@ -67,7 +67,7 @@ public class AciaTest6850 {
         verify(mockBus, never()).assertIrq();
 
         // Transmission should cause IRQ
-        acia.txRead();
+        acia.txRead(true);
 
         verify(mockBus, atLeastOnce()).assertIrq();
     }
@@ -86,7 +86,7 @@ public class AciaTest6850 {
         acia.write(DATA_REG, 'a');
 
         // Transmission should cause IRQ
-        acia.txRead();
+        acia.txRead(true);
 
         verify(mockBus, never()).assertIrq();
     }
@@ -95,7 +95,7 @@ public class AciaTest6850 {
     public void newAciaShouldHaveTxEmptyStatus() throws Exception {
         Acia acia = newAcia();
 
-        assertEquals(0x02, acia.read(CMD_STAT_REG) & 0x02);
+        assertEquals(0x02, acia.read(CMD_STAT_REG, true) & 0x02);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class AciaTest6850 {
         Acia acia = newAcia();
 
         acia.txWrite('a');
-        assertEquals(0x00, acia.read(CMD_STAT_REG) & 0x02);
+        assertEquals(0x00, acia.read(CMD_STAT_REG, true) & 0x02);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class AciaTest6850 {
 
         acia.rxWrite('a');
        
-        assertEquals(0x01, acia.read(CMD_STAT_REG) & 0x01);
+        assertEquals(0x01, acia.read(CMD_STAT_REG, true) & 0x01);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class AciaTest6850 {
         acia.rxWrite('a');
         acia.txWrite('b');
 
-        assertEquals(0x01, acia.read(CMD_STAT_REG) & 0x03);
+        assertEquals(0x01, acia.read(CMD_STAT_REG, true) & 0x03);
     }
     
     @Test
@@ -136,11 +136,11 @@ public class AciaTest6850 {
         acia.rxWrite('a');
         acia.rxWrite('b');
         
-        assertEquals(0x20, acia.read(CMD_STAT_REG) & 0x20);
+        assertEquals(0x20, acia.read(CMD_STAT_REG, true) & 0x20);
         
         // read should reset
-        acia.rxRead();
-        assertEquals(0x00, acia.read(CMD_STAT_REG) & 0x20);
+        acia.rxRead(true);
+        assertEquals(0x00, acia.read(CMD_STAT_REG, true) & 0x20);
         
     }
 
@@ -149,15 +149,15 @@ public class AciaTest6850 {
             throws Exception {
         Acia acia = newAcia();
 
-        assertEquals(0x00, acia.read(CMD_STAT_REG) & 0x01);
+        assertEquals(0x00, acia.read(CMD_STAT_REG, true) & 0x01);
         
         acia.rxWrite('a');
         
-        assertEquals(0x01, acia.read(CMD_STAT_REG) & 0x01);
+        assertEquals(0x01, acia.read(CMD_STAT_REG, true) & 0x01);
         
-        acia.rxRead();
+        acia.rxRead(true);
         
-        assertEquals(0x00, acia.read(CMD_STAT_REG) & 0x01);        
+        assertEquals(0x00, acia.read(CMD_STAT_REG, true) & 0x01);
         
     }
 }

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteModeTest.java
@@ -121,31 +121,31 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0x0e, 0x04, 0x12); // ASL $1204
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x7f00));
+        assertEquals(0x00, bus.read(0x7f00, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x7f01));
+        assertEquals(0x02, bus.read(0x7f01, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x3502));
+        assertEquals(0x04, bus.read(0x3502, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x88, bus.read(0x3503));
+        assertEquals(0x88, bus.read(0x3503, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1204));
+        assertEquals(0x00, bus.read(0x1204, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
@@ -165,8 +165,8 @@ public class CpuAbsoluteModeTest extends TestCase {
 
         // Old PC-1 should be on stack (i.e.: address of third byte of the
         // JSR instruction, 0x0204)
-        assertEquals(0x02, bus.read(0x1ff));
-        assertEquals(0x04, bus.read(0x1fe));
+        assertEquals(0x02, bus.read(0x1ff, true));
+        assertEquals(0x04, bus.read(0x1fe, true));
 
         // No flags should have changed.
         assertEquals(0x20, cpu.getProcessorStatus());
@@ -295,61 +295,61 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0x2e, 0x01, 0x12); // ROL $1201 (m=%10000001, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1200));
+        assertEquals(0x00, bus.read(0x1200, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x1201));
+        assertEquals(0x02, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step(2);
-        assertEquals(0x05, bus.read(0x1201));
+        assertEquals(0x05, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x0a, bus.read(0x1201));
+        assertEquals(0x0a, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x14, bus.read(0x1201));
+        assertEquals(0x14, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x28, bus.read(0x1201));
+        assertEquals(0x28, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x50, bus.read(0x1201));
+        assertEquals(0x50, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0xa0, bus.read(0x1201));
+        assertEquals(0xa0, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x1201));
+        assertEquals(0x40, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x81, bus.read(0x1201));
+        assertEquals(0x81, bus.read(0x1201, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -418,38 +418,38 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0x4e, 0x05, 0x12); // LSR $1205
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1200));
+        assertEquals(0x00, bus.read(0x1200, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1201));
+        assertEquals(0x00, bus.read(0x1201, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x1202));
+        assertEquals(0x01, bus.read(0x1202, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x22, bus.read(0x1203));
+        assertEquals(0x22, bus.read(0x1203, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x1204));
+        assertEquals(0x40, bus.read(0x1204, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         // Setting Carry should not affect the result.
         cpu.step(2);
-        assertEquals(0x01, bus.read(0x1205));
+        assertEquals(0x01, bus.read(0x1205, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -654,61 +654,61 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0x6e, 0x11, 0x12); // ROR $1201 (m=%00010000, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1210));
+        assertEquals(0x00, bus.read(0x1210, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x08, bus.read(0x1211));
+        assertEquals(0x08, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x1211));
+        assertEquals(0x04, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x1211));
+        assertEquals(0x02, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x1211));
+        assertEquals(0x01, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1211));
+        assertEquals(0x00, bus.read(0x1211, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x1211));
+        assertEquals(0x80, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x1211));
+        assertEquals(0x40, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x20, bus.read(0x1211));
+        assertEquals(0x20, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x10, bus.read(0x1211));
+        assertEquals(0x10, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -720,7 +720,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setYRegister(0x00);
         bus.loadProgram(0x8c, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x00, bus.read(0x1210));
+        assertEquals(0x00, bus.read(0x1210, true));
         // STY should have NO effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -730,7 +730,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setYRegister(0x0f);
         bus.loadProgram(0x8c, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x1210));
+        assertEquals(0x0f, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -739,7 +739,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setYRegister(0x80);
         bus.loadProgram(0x8c, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x80, bus.read(0x1210));
+        assertEquals(0x80, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -750,7 +750,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x8d, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x00, bus.read(0x1210));
+        assertEquals(0x00, bus.read(0x1210, true));
         // STA should have NO effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -760,7 +760,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x8d, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x1210));
+        assertEquals(0x0f, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -769,7 +769,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x8d, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x80, bus.read(0x1210));
+        assertEquals(0x80, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -780,7 +780,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setXRegister(0x00);
         bus.loadProgram(0x8e, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x00, bus.read(0x1210));
+        assertEquals(0x00, bus.read(0x1210, true));
         // STX should have NO effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -790,7 +790,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setXRegister(0x0f);
         bus.loadProgram(0x8e, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x1210));
+        assertEquals(0x0f, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -799,7 +799,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.setXRegister(0x80);
         bus.loadProgram(0x8e, 0x10, 0x12);
         cpu.step();
-        assertEquals(0x80, bus.read(0x1210));
+        assertEquals(0x80, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -957,22 +957,22 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0xce, 0x13, 0x12); // DEC $1213
 
         cpu.step();
-        assertEquals(0xff, bus.read(0x1210));
+        assertEquals(0xff, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1211));
+        assertEquals(0x00, bus.read(0x1211, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x7f, bus.read(0x1212));
+        assertEquals(0x7f, bus.read(0x1212, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0xfe, bus.read(0x1213));
+        assertEquals(0xfe, bus.read(0x1213, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
     }
@@ -1213,17 +1213,17 @@ public class CpuAbsoluteModeTest extends TestCase {
                         0xee, 0x12, 0x12); // INC $1212
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x1210));
+        assertEquals(0x01, bus.read(0x1210, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x1211));
+        assertEquals(0x80, bus.read(0x1211, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1212));
+        assertEquals(0x00, bus.read(0x1212, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteXModeTest.java
@@ -117,31 +117,31 @@ public class CpuAbsoluteXModeTest extends TestCase {
                         0x1e, 0x04, 0x2c); // ASL $2c04,X
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x2c30));
+        assertEquals(0x00, bus.read(0x2c30, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x2c31));
+        assertEquals(0x02, bus.read(0x2c31, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x2c32));
+        assertEquals(0x04, bus.read(0x2c32, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x88, bus.read(0x2c33));
+        assertEquals(0x88, bus.read(0x2c33, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x2c34));
+        assertEquals(0x00, bus.read(0x2c34, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
@@ -229,61 +229,61 @@ public class CpuAbsoluteXModeTest extends TestCase {
                         0x3e, 0x01, 0x10); // ROL $1001,X (m=%10000001, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x1070));
+        assertEquals(0x00, bus.read(0x1070, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x1071));
+        assertEquals(0x02, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step(2);
-        assertEquals(0x05, bus.read(0x1071));
+        assertEquals(0x05, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x0a, bus.read(0x1071));
+        assertEquals(0x0a, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x14, bus.read(0x1071));
+        assertEquals(0x14, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x28, bus.read(0x1071));
+        assertEquals(0x28, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x50, bus.read(0x1071));
+        assertEquals(0x50, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0xa0, bus.read(0x1071));
+        assertEquals(0xa0, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x1071));
+        assertEquals(0x40, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x81, bus.read(0x1071));
+        assertEquals(0x81, bus.read(0x1071, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -346,38 +346,38 @@ public class CpuAbsoluteXModeTest extends TestCase {
                         0x5e, 0x05, 0xab); // LSR $ab05,X
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab30));
+        assertEquals(0x00, bus.read(0xab30, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab31));
+        assertEquals(0x00, bus.read(0xab31, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0xab32));
+        assertEquals(0x01, bus.read(0xab32, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x22, bus.read(0xab33));
+        assertEquals(0x22, bus.read(0xab33, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0xab34));
+        assertEquals(0x40, bus.read(0xab34, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         // Setting Carry should not affect the result.
         cpu.step(2);
-        assertEquals(0x01, bus.read(0xab35));
+        assertEquals(0x01, bus.read(0xab35, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -609,61 +609,61 @@ public class CpuAbsoluteXModeTest extends TestCase {
         cpu.setXRegister(0x30);
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab40));
+        assertEquals(0x00, bus.read(0xab40, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x08, bus.read(0xab41));
+        assertEquals(0x08, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0xab41));
+        assertEquals(0x04, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0xab41));
+        assertEquals(0x02, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0xab41));
+        assertEquals(0x01, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab41));
+        assertEquals(0x00, bus.read(0xab41, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0xab41));
+        assertEquals(0x80, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0xab41));
+        assertEquals(0x40, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x20, bus.read(0xab41));
+        assertEquals(0x20, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x10, bus.read(0xab41));
+        assertEquals(0x10, bus.read(0xab41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -677,7 +677,7 @@ public class CpuAbsoluteXModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x00, bus.read(0xab40));
+        assertEquals(0x00, bus.read(0xab40, true));
         // STA should have NO affect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -688,7 +688,7 @@ public class CpuAbsoluteXModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x0f, bus.read(0xab40));
+        assertEquals(0x0f, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -698,7 +698,7 @@ public class CpuAbsoluteXModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x80, bus.read(0xab40));
+        assertEquals(0x80, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -808,22 +808,22 @@ public class CpuAbsoluteXModeTest extends TestCase {
         cpu.setXRegister(0x30);
 
         cpu.step();
-        assertEquals(0xff, bus.read(0xab40));
+        assertEquals(0xff, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab41));
+        assertEquals(0x00, bus.read(0xab41, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x7f, bus.read(0xab42));
+        assertEquals(0x7f, bus.read(0xab42, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0xfe, bus.read(0xab43));
+        assertEquals(0xfe, bus.read(0xab43, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
     }
@@ -1051,17 +1051,17 @@ public class CpuAbsoluteXModeTest extends TestCase {
                         0xfe, 0x12, 0xab); // INC $ab12,X
 
         cpu.step();
-        assertEquals(0x01, bus.read(0xab30));
+        assertEquals(0x01, bus.read(0xab30, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0xab31));
+        assertEquals(0x80, bus.read(0xab31, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0xab32));
+        assertEquals(0x00, bus.read(0xab32, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteYModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteYModeTest.java
@@ -411,7 +411,7 @@ public class CpuAbsoluteYModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x99, 0x10, 0xab); // STA $ab10,Y
         cpu.step();
-        assertEquals(0x00, bus.read(0xab40));
+        assertEquals(0x00, bus.read(0xab40, true));
         // STA should have NO effect on flags
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -423,7 +423,7 @@ public class CpuAbsoluteYModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x99, 0x10, 0xab); // STA $ab10,Y
         cpu.step();
-        assertEquals(0x0f, bus.read(0xab40));
+        assertEquals(0x0f, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -433,7 +433,7 @@ public class CpuAbsoluteYModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x99, 0x10, 0xab); // STA $ab10,Y
         cpu.step();
-        assertEquals(0x80, bus.read(0xab40));
+        assertEquals(0x80, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CpuImpliedModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuImpliedModeTest.java
@@ -101,10 +101,10 @@ public class CpuImpliedModeTest {
         cpu.step(); // Triggers the BRK
 
         // Was at PC = 0x204.  PC+1 should now be on the stack
-        assertEquals(0x02, bus.read(0x1ff)); // PC high byte
-        assertEquals(0x05, bus.read(0x1fe)); // PC low byte
+        assertEquals(0x02, bus.read(0x1ff, true)); // PC high byte
+        assertEquals(0x05, bus.read(0x1fe, true)); // PC low byte
         assertEquals(0x20 | Cpu.P_CARRY | Cpu.P_OVERFLOW | Cpu.P_BREAK,
-                     bus.read(0x1fd));       // Processor Status, with B set
+                     bus.read(0x1fd, true));       // Processor Status, with B set
 
         // Interrupt vector held 0x1234, so we should be there.
         assertEquals(0x1234, cpu.getProgramCounter());
@@ -149,10 +149,10 @@ public class CpuImpliedModeTest {
 
 
         // Was at PC = 0x204.  PC+1 should now be on the stack
-        assertEquals(0x02, bus.read(0x1ff)); // PC high byte
-        assertEquals(0x05, bus.read(0x1fe)); // PC low byte
+        assertEquals(0x02, bus.read(0x1ff, true)); // PC high byte
+        assertEquals(0x05, bus.read(0x1fe, true)); // PC low byte
         assertEquals(0x20 | Cpu.P_CARRY | Cpu.P_OVERFLOW | Cpu.P_BREAK | Cpu.P_IRQ_DISABLE,
-                     bus.read(0x1fd));       // Processor Status, with B set
+                     bus.read(0x1fd, true));       // Processor Status, with B set
 
         // Interrupt vector held 0x1234, so we should be there.
         assertEquals(0x1234, cpu.getProgramCounter());

--- a/src/test/java/com/loomcom/symon/CpuIndexedIndirectModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndexedIndirectModeTest.java
@@ -87,7 +87,7 @@ public class CpuIndexedIndirectModeTest {
         cpu.step(1);
 
         assertEquals(0x35, cpu.getAccumulator());
-        assertEquals(0x31, bus.read(0xc51f));
+        assertEquals(0x31, bus.read(0xc51f, true));
     }
 
     @Test
@@ -103,6 +103,6 @@ public class CpuIndexedIndirectModeTest {
         cpu.step(1);
 
         assertEquals(0x11, cpu.getAccumulator());
-        assertEquals(0x31, bus.read(0xc51f));
+        assertEquals(0x31, bus.read(0xc51f, true));
     }
 }

--- a/src/test/java/com/loomcom/symon/CpuIndirectIndexedModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndirectIndexedModeTest.java
@@ -62,7 +62,7 @@ public class CpuIndirectIndexedModeTest {
         cpu.step(1);
 
         assertEquals(0xf3, cpu.getAccumulator());
-        assertEquals(0xe3, bus.read(0xd828));
+        assertEquals(0xe3, bus.read(0xd828, true));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class CpuIndirectIndexedModeTest {
         cpu.step(1);
 
         assertEquals(0x22, cpu.getAccumulator());
-        assertEquals(0xe3, bus.read(0xd828));
+        assertEquals(0xe3, bus.read(0xd828, true));
     }
 
 }

--- a/src/test/java/com/loomcom/symon/CpuIndirectXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndirectXModeTest.java
@@ -411,7 +411,7 @@ public class CpuIndirectXModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x00, bus.read(0xab40));
+        assertEquals(0x00, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -422,7 +422,7 @@ public class CpuIndirectXModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x0f, bus.read(0xab40));
+        assertEquals(0x0f, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -432,7 +432,7 @@ public class CpuIndirectXModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x9d, 0x10, 0xab); // STA $ab10,X
         cpu.step();
-        assertEquals(0x80, bus.read(0xab40));
+        assertEquals(0x80, bus.read(0xab40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CpuTest.java
+++ b/src/test/java/com/loomcom/symon/CpuTest.java
@@ -71,61 +71,61 @@ public class CpuTest extends TestCase {
 
     public void testStackPush() throws MemoryAccessException {
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x00, bus.read(0x1ff));
+        assertEquals(0x00, bus.read(0x1ff, true));
 
         cpu.stackPush(0x06);
         assertEquals(0xfe, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
+        assertEquals(0x06, bus.read(0x1ff, true));
 
         cpu.stackPush(0x05);
         assertEquals(0xfd, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
-        assertEquals(0x05, bus.read(0x1fe));
+        assertEquals(0x06, bus.read(0x1ff, true));
+        assertEquals(0x05, bus.read(0x1fe, true));
 
         cpu.stackPush(0x04);
         assertEquals(0xfc, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
-        assertEquals(0x05, bus.read(0x1fe));
-        assertEquals(0x04, bus.read(0x1fd));
+        assertEquals(0x06, bus.read(0x1ff, true));
+        assertEquals(0x05, bus.read(0x1fe, true));
+        assertEquals(0x04, bus.read(0x1fd, true));
 
         cpu.stackPush(0x03);
         assertEquals(0xfb, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
-        assertEquals(0x05, bus.read(0x1fe));
-        assertEquals(0x04, bus.read(0x1fd));
-        assertEquals(0x03, bus.read(0x1fc));
+        assertEquals(0x06, bus.read(0x1ff, true));
+        assertEquals(0x05, bus.read(0x1fe, true));
+        assertEquals(0x04, bus.read(0x1fd, true));
+        assertEquals(0x03, bus.read(0x1fc, true));
 
         cpu.stackPush(0x02);
         assertEquals(0xfa, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
-        assertEquals(0x05, bus.read(0x1fe));
-        assertEquals(0x04, bus.read(0x1fd));
-        assertEquals(0x03, bus.read(0x1fc));
-        assertEquals(0x02, bus.read(0x1fb));
+        assertEquals(0x06, bus.read(0x1ff, true));
+        assertEquals(0x05, bus.read(0x1fe, true));
+        assertEquals(0x04, bus.read(0x1fd, true));
+        assertEquals(0x03, bus.read(0x1fc, true));
+        assertEquals(0x02, bus.read(0x1fb, true));
 
         cpu.stackPush(0x01);
         assertEquals(0xf9, cpu.getStackPointer());
-        assertEquals(0x06, bus.read(0x1ff));
-        assertEquals(0x05, bus.read(0x1fe));
-        assertEquals(0x04, bus.read(0x1fd));
-        assertEquals(0x03, bus.read(0x1fc));
-        assertEquals(0x02, bus.read(0x1fb));
-        assertEquals(0x01, bus.read(0x1fa));
+        assertEquals(0x06, bus.read(0x1ff, true));
+        assertEquals(0x05, bus.read(0x1fe, true));
+        assertEquals(0x04, bus.read(0x1fd, true));
+        assertEquals(0x03, bus.read(0x1fc, true));
+        assertEquals(0x02, bus.read(0x1fb, true));
+        assertEquals(0x01, bus.read(0x1fa, true));
     }
 
     public void testStackPushWrapsAroundToStackTop() throws MemoryAccessException {
         cpu.setStackPointer(0x01);
 
         cpu.stackPush(0x01);
-        assertEquals(0x01, bus.read(0x101));
+        assertEquals(0x01, bus.read(0x101, true));
         assertEquals(0x00, cpu.getStackPointer());
 
         cpu.stackPush(0x02);
-        assertEquals(0x02, bus.read(0x100));
+        assertEquals(0x02, bus.read(0x100, true));
         assertEquals(0xff, cpu.getStackPointer());
 
         cpu.stackPush(0x03);
-        assertEquals(0x03, bus.read(0x1ff));
+        assertEquals(0x03, bus.read(0x1ff, true));
         assertEquals(0xfe, cpu.getStackPointer());
     }
 

--- a/src/test/java/com/loomcom/symon/CpuZeroPageModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageModeTest.java
@@ -119,31 +119,31 @@ public class CpuZeroPageModeTest extends TestCase {
                         0x06, 0x04);
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x0000));
+        assertEquals(0x00, bus.read(0x0000, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x0001));
+        assertEquals(0x02, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x0002));
+        assertEquals(0x04, bus.read(0x0002, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x88, bus.read(0x0003));
+        assertEquals(0x88, bus.read(0x0003, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x0004));
+        assertEquals(0x00, bus.read(0x0004, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
@@ -274,61 +274,61 @@ public class CpuZeroPageModeTest extends TestCase {
                         0x26, 0x01); // ROL $01 (m=%10000001, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x0000));
+        assertEquals(0x00, bus.read(0x0000, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x0001));
+        assertEquals(0x02, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step(2);
-        assertEquals(0x05, bus.read(0x0001));
+        assertEquals(0x05, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x0a, bus.read(0x0001));
+        assertEquals(0x0a, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x14, bus.read(0x0001));
+        assertEquals(0x14, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x28, bus.read(0x0001));
+        assertEquals(0x28, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x50, bus.read(0x0001));
+        assertEquals(0x50, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0xa0, bus.read(0x0001));
+        assertEquals(0xa0, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x0001));
+        assertEquals(0x40, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x81, bus.read(0x0001));
+        assertEquals(0x81, bus.read(0x0001, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -387,38 +387,38 @@ public class CpuZeroPageModeTest extends TestCase {
                         0x46, 0x05); // LSR $05
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x0000));
+        assertEquals(0x00, bus.read(0x0000, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x0001));
+        assertEquals(0x00, bus.read(0x0001, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x0002));
+        assertEquals(0x01, bus.read(0x0002, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x22, bus.read(0x0003));
+        assertEquals(0x22, bus.read(0x0003, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x0004));
+        assertEquals(0x40, bus.read(0x0004, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         // Setting Carry should not affect the result.
         cpu.step(2);
-        assertEquals(0x01, bus.read(0x0005));
+        assertEquals(0x01, bus.read(0x0005, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -623,61 +623,61 @@ public class CpuZeroPageModeTest extends TestCase {
                         0x66, 0x11); // ROR $01 (m=%00010000, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x10));
+        assertEquals(0x00, bus.read(0x10, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x08, bus.read(0x11));
+        assertEquals(0x08, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x11));
+        assertEquals(0x04, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x11));
+        assertEquals(0x02, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x11));
+        assertEquals(0x01, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x11));
+        assertEquals(0x00, bus.read(0x11, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x11));
+        assertEquals(0x80, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x11));
+        assertEquals(0x40, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x20, bus.read(0x11));
+        assertEquals(0x20, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x10, bus.read(0x11));
+        assertEquals(0x10, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -689,7 +689,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setYRegister(0x00);
         bus.loadProgram(0x84, 0x10);
         cpu.step();
-        assertEquals(0x00, bus.read(0x10));
+        assertEquals(0x00, bus.read(0x10, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -699,7 +699,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setYRegister(0x0f);
         bus.loadProgram(0x84, 0x10);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x10));
+        assertEquals(0x0f, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -708,7 +708,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setYRegister(0x80);
         bus.loadProgram(0x84, 0x10);
         cpu.step();
-        assertEquals(0x80, bus.read(0x10));
+        assertEquals(0x80, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -719,7 +719,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x85, 0x10);
         cpu.step();
-        assertEquals(0x00, bus.read(0x10));
+        assertEquals(0x00, bus.read(0x10, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -729,7 +729,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x85, 0x10);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x10));
+        assertEquals(0x0f, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -738,7 +738,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x85, 0x10);
         cpu.step();
-        assertEquals(0x80, bus.read(0x10));
+        assertEquals(0x80, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -749,7 +749,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setXRegister(0x00);
         bus.loadProgram(0x86, 0x10);
         cpu.step();
-        assertEquals(0x00, bus.read(0x10));
+        assertEquals(0x00, bus.read(0x10, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -759,7 +759,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setXRegister(0x0f);
         bus.loadProgram(0x86, 0x10);
         cpu.step();
-        assertEquals(0x0f, bus.read(0x10));
+        assertEquals(0x0f, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -768,7 +768,7 @@ public class CpuZeroPageModeTest extends TestCase {
         cpu.setXRegister(0x80);
         bus.loadProgram(0x86, 0x10);
         cpu.step();
-        assertEquals(0x80, bus.read(0x10));
+        assertEquals(0x80, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -926,22 +926,22 @@ public class CpuZeroPageModeTest extends TestCase {
                         0xc6, 0x13); // DEC $13
 
         cpu.step();
-        assertEquals(0xff, bus.read(0x10));
+        assertEquals(0xff, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x11));
+        assertEquals(0x00, bus.read(0x11, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x7f, bus.read(0x12));
+        assertEquals(0x7f, bus.read(0x12, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0xfe, bus.read(0x13));
+        assertEquals(0xfe, bus.read(0x13, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
     }
@@ -1182,17 +1182,17 @@ public class CpuZeroPageModeTest extends TestCase {
                         0xe6, 0x12); // INC $12
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x10));
+        assertEquals(0x01, bus.read(0x10, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x11));
+        assertEquals(0x80, bus.read(0x11, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x12));
+        assertEquals(0x00, bus.read(0x12, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CpuZeroPageXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageXModeTest.java
@@ -131,38 +131,38 @@ public class CpuZeroPageXModeTest extends TestCase {
                         0x16, 0xd2); // ASL $d2,X
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x30));
+        assertEquals(0x00, bus.read(0x30, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x31));
+        assertEquals(0x02, bus.read(0x31, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x32));
+        assertEquals(0x04, bus.read(0x32, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x88, bus.read(0x33));
+        assertEquals(0x88, bus.read(0x33, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x34));
+        assertEquals(0x00, bus.read(0x34, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         // Should wrap around, d2 + 30 = 02
         cpu.step();
-        assertEquals(0x02, bus.read(0x02));
+        assertEquals(0x02, bus.read(0x02, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -251,61 +251,61 @@ public class CpuZeroPageXModeTest extends TestCase {
                         0x36, 0x01); // ROL $01,X (m=%10000001, c=0)
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x70));
+        assertEquals(0x00, bus.read(0x70, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x71));
+        assertEquals(0x02, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step(2);
-        assertEquals(0x05, bus.read(0x71));
+        assertEquals(0x05, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x0a, bus.read(0x71));
+        assertEquals(0x0a, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x14, bus.read(0x71));
+        assertEquals(0x14, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x28, bus.read(0x71));
+        assertEquals(0x28, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x50, bus.read(0x71));
+        assertEquals(0x50, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0xa0, bus.read(0x71));
+        assertEquals(0xa0, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x71));
+        assertEquals(0x40, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x81, bus.read(0x71));
+        assertEquals(0x81, bus.read(0x71, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -368,38 +368,38 @@ public class CpuZeroPageXModeTest extends TestCase {
                         0x56, 0x05); // LSR $05,X
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x30));
+        assertEquals(0x00, bus.read(0x30, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x31));
+        assertEquals(0x00, bus.read(0x31, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x32));
+        assertEquals(0x01, bus.read(0x32, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x22, bus.read(0x33));
+        assertEquals(0x22, bus.read(0x33, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x34));
+        assertEquals(0x40, bus.read(0x34, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         // Setting Carry should not affect the result.
         cpu.step(2);
-        assertEquals(0x01, bus.read(0x35));
+        assertEquals(0x01, bus.read(0x35, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -641,61 +641,61 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setXRegister(0x30);
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x40));
+        assertEquals(0x00, bus.read(0x40, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x08, bus.read(0x41));
+        assertEquals(0x08, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x04, bus.read(0x41));
+        assertEquals(0x04, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x02, bus.read(0x41));
+        assertEquals(0x02, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x41));
+        assertEquals(0x01, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x41));
+        assertEquals(0x00, bus.read(0x41, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertTrue(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x41));
+        assertEquals(0x80, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x40, bus.read(0x41));
+        assertEquals(0x40, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x20, bus.read(0x41));
+        assertEquals(0x20, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
 
         cpu.step();
-        assertEquals(0x10, bus.read(0x41));
+        assertEquals(0x10, bus.read(0x41, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
         assertFalse(cpu.getCarryFlag());
@@ -708,7 +708,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setYRegister(0x00);
         bus.loadProgram(0x94, 0x10); // STY $10,X
         cpu.step();
-        assertEquals(0x00, bus.read(0x40));
+        assertEquals(0x00, bus.read(0x40, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -719,7 +719,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setYRegister(0x0f);
         bus.loadProgram(0x94, 0x10); // STY $10,X
         cpu.step();
-        assertEquals(0x0f, bus.read(0x40));
+        assertEquals(0x0f, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -729,7 +729,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setYRegister(0x80);
         bus.loadProgram(0x94, 0x10); // STY $10,X
         cpu.step();
-        assertEquals(0x80, bus.read(0x40));
+        assertEquals(0x80, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -742,7 +742,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setAccumulator(0x00);
         bus.loadProgram(0x95, 0x10); // STA $10,X
         cpu.step();
-        assertEquals(0x00, bus.read(0x40));
+        assertEquals(0x00, bus.read(0x40, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -753,7 +753,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setAccumulator(0x0f);
         bus.loadProgram(0x95, 0x10); // STA $10,X
         cpu.step();
-        assertEquals(0x0f, bus.read(0x40));
+        assertEquals(0x0f, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -763,7 +763,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setAccumulator(0x80);
         bus.loadProgram(0x95, 0x10); // STA $10,X
         cpu.step();
-        assertEquals(0x80, bus.read(0x40));
+        assertEquals(0x80, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }
@@ -873,22 +873,22 @@ public class CpuZeroPageXModeTest extends TestCase {
         cpu.setXRegister(0x30);
 
         cpu.step();
-        assertEquals(0xff, bus.read(0x40));
+        assertEquals(0xff, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x41));
+        assertEquals(0x00, bus.read(0x41, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x7f, bus.read(0x42));
+        assertEquals(0x7f, bus.read(0x42, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0xfe, bus.read(0x43));
+        assertEquals(0xfe, bus.read(0x43, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
     }
@@ -1116,17 +1116,17 @@ public class CpuZeroPageXModeTest extends TestCase {
                         0xf6, 0x12); // INC $12,X
 
         cpu.step();
-        assertEquals(0x01, bus.read(0x30));
+        assertEquals(0x01, bus.read(0x30, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x80, bus.read(0x31));
+        assertEquals(0x80, bus.read(0x31, true));
         assertFalse(cpu.getZeroFlag());
         assertTrue(cpu.getNegativeFlag());
 
         cpu.step();
-        assertEquals(0x00, bus.read(0x32));
+        assertEquals(0x00, bus.read(0x32, true));
         assertTrue(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CpuZeroPageYModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageYModeTest.java
@@ -47,7 +47,7 @@ public class CpuZeroPageYModeTest extends TestCase {
         cpu.setXRegister(0x00);
         bus.loadProgram(0x96, 0x10);  // STX $10,Y
         cpu.step();
-        assertEquals(0x00, bus.read(0x40));
+        assertEquals(0x00, bus.read(0x40, true));
         // Should have no effect on flags.
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
@@ -57,7 +57,7 @@ public class CpuZeroPageYModeTest extends TestCase {
         cpu.setXRegister(0x0f);
         bus.loadProgram(0x96, 0x10);  // STX $10,Y
         cpu.step();
-        assertEquals(0x0f, bus.read(0x40));
+        assertEquals(0x0f, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
 
@@ -66,7 +66,7 @@ public class CpuZeroPageYModeTest extends TestCase {
         cpu.setXRegister(0x80);
         bus.loadProgram(0x96, 0x10);  // STX $10,Y
         cpu.step();
-        assertEquals(0x80, bus.read(0x40));
+        assertEquals(0x80, bus.read(0x40, true));
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getNegativeFlag());
     }

--- a/src/test/java/com/loomcom/symon/CrtcTest.java
+++ b/src/test/java/com/loomcom/symon/CrtcTest.java
@@ -242,19 +242,19 @@ public class CrtcTest {
         crtc.write(0, 12); // High byte
 
         crtc.write(1, 0x03);
-        assertEquals(0, crtc.read(1));
+        assertEquals(0, crtc.read(1, true));
 
         crtc.write(1, 0x70);
-        assertEquals(0, crtc.read(1));
+        assertEquals(0, crtc.read(1, true));
 
 
         crtc.write(0, 13); // Low byte
 
         crtc.write(1, 0xff);
-        assertEquals(0, crtc.read(1));
+        assertEquals(0, crtc.read(1, true));
 
         crtc.write(1, 0x0e);
-        assertEquals(0, crtc.read(1));
+        assertEquals(0, crtc.read(1, true));
     }
 
 
@@ -278,10 +278,10 @@ public class CrtcTest {
         crtc.write(0, 14);
 
         crtc.write(1, 0x3f);
-        assertEquals(0x3f, crtc.read(1));
+        assertEquals(0x3f, crtc.read(1, true));
 
         crtc.write(1, 0x70);
-        assertEquals(0x70, crtc.read(1));
+        assertEquals(0x70, crtc.read(1, true));
     }
 
     @Test
@@ -313,13 +313,13 @@ public class CrtcTest {
         crtc.write(0, 15);
 
         crtc.write(1, 0x00);
-        assertEquals(0x00, crtc.read(1));
+        assertEquals(0x00, crtc.read(1, true));
 
         crtc.write(1, 0x1f);
-        assertEquals(0x1f, crtc.read(1));
+        assertEquals(0x1f, crtc.read(1, true));
 
         crtc.write(1, 0xff);
-        assertEquals(0xff, crtc.read(1));
+        assertEquals(0xff, crtc.read(1, true));
     }
 
 


### PR DESCRIPTION
Fix for Issue #16: Memory window should not reset device registers
Adds bool "cpuAccess" to read functions so that the memory window does not reset the ACIA status register on read. 

Added tests, all tests pass.
Tests were added to AciaTest.java but not AciaTest6850.java as it does not appear to be referenced and I could not find out how to add this step, @sethm is this intentional?