### PR TITLE
Make the Processor Status register match a real 6502 at power-on.

### DIFF
--- a/src/main/java/com/loomcom/symon/Cpu.java
+++ b/src/main/java/com/loomcom/symon/Cpu.java
@@ -126,7 +126,7 @@ public class Cpu implements InstructionTable {
         // Clear status register bits.
         state.carryFlag = false;
         state.zeroFlag = false;
-        state.irqDisableFlag = false;
+        state.irqDisableFlag = true;
         state.decimalModeFlag = false;
         state.breakFlag = false;
         state.overflowFlag = false;

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteModeTest.java
@@ -29,7 +29,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*
@@ -169,7 +169,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         assertEquals(0x04, bus.read(0x1fe, true));
 
         // No flags should have changed.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /* BIT - Bit Test - $2c */
@@ -362,7 +362,7 @@ public class CpuAbsoluteModeTest extends TestCase {
         cpu.step();
         assertEquals(0x3400, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /* EOR - Exclusive OR - $4d */

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteXModeTest.java
@@ -29,7 +29,7 @@ public class CpuAbsoluteXModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuAbsoluteYModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAbsoluteYModeTest.java
@@ -29,7 +29,7 @@ public class CpuAbsoluteYModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuAccumulatorModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuAccumulatorModeTest.java
@@ -30,7 +30,7 @@ public class CpuAccumulatorModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
    /*

--- a/src/test/java/com/loomcom/symon/CpuImmediateModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuImmediateModeTest.java
@@ -29,7 +29,7 @@ public class CpuImmediateModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuImpliedModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuImpliedModeTest.java
@@ -33,7 +33,7 @@ public class CpuImpliedModeTest {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*
@@ -76,6 +76,7 @@ public class CpuImpliedModeTest {
     public void test_BRK() throws MemoryAccessException {
         cpu.setCarryFlag();
         cpu.setOverflowFlag();
+        cpu.clearIrqDisableFlag();
         assertEquals(0x20 | Cpu.P_CARRY | Cpu.P_OVERFLOW,
                      cpu.getProcessorStatus());
         assertEquals(0x00, cpu.stackPeek());
@@ -343,7 +344,7 @@ public class CpuImpliedModeTest {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x201, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /* PHA - Push Accumulator - $48 */
@@ -432,7 +433,7 @@ public class CpuImpliedModeTest {
         cpu.step();
 
         assertEquals(0x0f12, cpu.getProgramCounter());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /* SEC - Set Carry Flag - $38 */

--- a/src/test/java/com/loomcom/symon/CpuIndexedIndirectModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndexedIndirectModeTest.java
@@ -31,7 +31,7 @@ public class CpuIndexedIndirectModeTest {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     @Test

--- a/src/test/java/com/loomcom/symon/CpuIndirectIndexedModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndirectIndexedModeTest.java
@@ -31,7 +31,7 @@ public class CpuIndirectIndexedModeTest {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     @Test

--- a/src/test/java/com/loomcom/symon/CpuIndirectModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndirectModeTest.java
@@ -29,7 +29,7 @@ public class CpuIndirectModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*
@@ -48,7 +48,7 @@ public class CpuIndirectModeTest extends TestCase {
         cpu.step();
         assertEquals(0x5400, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     public void test_JMP_with_ROR_Bug() throws MemoryAccessException {
@@ -60,7 +60,7 @@ public class CpuIndirectModeTest extends TestCase {
         cpu.step();
         assertEquals(0x2200, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     public void test_JMP_withIndirectBug() throws MemoryAccessException {
@@ -72,7 +72,7 @@ public class CpuIndirectModeTest extends TestCase {
         cpu.step();
         assertEquals(0x2200, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     public void test_JMP_withOutIndirectBug() throws MemoryAccessException {
@@ -84,7 +84,7 @@ public class CpuIndirectModeTest extends TestCase {
         cpu.step();
         assertEquals(0x5400, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     public void test_JMP_cmos() throws MemoryAccessException {
@@ -96,7 +96,7 @@ public class CpuIndirectModeTest extends TestCase {
         cpu.step();
         assertEquals(0x5400, cpu.getProgramCounter());
         // No change to status flags.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
 }

--- a/src/test/java/com/loomcom/symon/CpuIndirectXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuIndirectXModeTest.java
@@ -28,7 +28,7 @@ public class CpuIndirectXModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuRelativeModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuRelativeModeTest.java
@@ -29,7 +29,7 @@ public class CpuRelativeModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
   /*

--- a/src/test/java/com/loomcom/symon/CpuTest.java
+++ b/src/test/java/com/loomcom/symon/CpuTest.java
@@ -44,7 +44,7 @@ public class CpuTest extends TestCase {
         assertEquals(0x0200, cpu.getProgramCounter());
         assertFalse(cpu.getCarryFlag());
         assertFalse(cpu.getZeroFlag());
-        assertFalse(cpu.getIrqDisableFlag());
+        assertTrue(cpu.getIrqDisableFlag());
         assertFalse(cpu.getDecimalModeFlag());
         assertFalse(cpu.getBreakFlag());
         assertFalse(cpu.getOverflowFlag());
@@ -205,14 +205,12 @@ public class CpuTest extends TestCase {
     }
 
     public void testGetProcessorStatus() {
-        // By default, no flags are set.  Remember, bit 5
+        // By default, only "interrupt disable" is set.  Remember, bit 5
         // is always '1'.
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
         cpu.setCarryFlag();
-        assertEquals(0x21, cpu.getProcessorStatus());
+        assertEquals(0x25, cpu.getProcessorStatus());
         cpu.setZeroFlag();
-        assertEquals(0x23, cpu.getProcessorStatus());
-        cpu.setIrqDisableFlag();
         assertEquals(0x27, cpu.getProcessorStatus());
         cpu.setDecimalModeFlag();
         assertEquals(0x2f, cpu.getProcessorStatus());
@@ -237,13 +235,16 @@ public class CpuTest extends TestCase {
         assertEquals(0xa0, cpu.getProcessorStatus());
         cpu.clearNegativeFlag();
         assertEquals(0x20, cpu.getProcessorStatus());
+
+        cpu.setIrqDisableFlag();
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     public void testSetProcessorStatus() {
         // Default
         assertFalse(cpu.getZeroFlag());
         assertFalse(cpu.getZeroFlag());
-        assertFalse(cpu.getIrqDisableFlag());
+        assertTrue(cpu.getIrqDisableFlag());
         assertFalse(cpu.getDecimalModeFlag());
         assertFalse(cpu.getBreakFlag());
         assertFalse(cpu.getOverflowFlag());

--- a/src/test/java/com/loomcom/symon/CpuZeroPageModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageModeTest.java
@@ -29,7 +29,7 @@ public class CpuZeroPageModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuZeroPageXModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageXModeTest.java
@@ -29,7 +29,7 @@ public class CpuZeroPageXModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*

--- a/src/test/java/com/loomcom/symon/CpuZeroPageYModeTest.java
+++ b/src/test/java/com/loomcom/symon/CpuZeroPageYModeTest.java
@@ -29,7 +29,7 @@ public class CpuZeroPageYModeTest extends TestCase {
         assertEquals(0, cpu.getYRegister());
         assertEquals(0x200, cpu.getProgramCounter());
         assertEquals(0xff, cpu.getStackPointer());
-        assertEquals(0x20, cpu.getProcessorStatus());
+        assertEquals(0x24, cpu.getProcessorStatus());
     }
 
     /*


### PR DESCRIPTION
When describing the CPU's reset pin, the W65C02S data sheet says:

> All Registers are initialized by software except the Decimal and Interrupt disable mode select bits of the Processor Status Register (P) are initialized by hardware.

It then has a diagram of the power-on state of the processor status register:

>     7 6 5 4 3 2 1 0
>     * * 1 1 0 1 * *
>     N V - B D I Z C
>
> \* = software initialized

Confusingly the text indicates that only the D and I flags are initialised by hardware, while the diagram indicates that the B flag is initialised too.

Meanwhile, https://www.nesdev.org/wiki/CPU_power_up_state says that the power-on state of the NES CPU is $34 (exactly matching the diagram above) but https://www.nesdev.org/wiki/Status_flags#The_B_flag says that the B flag does not physically exist within P register, it's only relevant in the copy of P that gets pushed to the stack by BRK (set), PHP (set), or an interrupt signal (cleared).

As a result, the most sensible power-on state for the processor status register is with the "interrupt disable" flag set and everything else cleared.