### PR TITLE
Minor cleanups in Acia6551.jar

### DIFF
--- a/src/main/java/com/loomcom/symon/devices/Acia6551.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia6551.java
@@ -116,7 +116,7 @@ public class Acia6551 extends Acia {
         if (data == 0) {
             reset();
         } else {
-            // Mask the lower three bits to get the baud rate.
+            // Mask the lower four bits to get the baud rate.
             int baudSelector = data & 0x0f;
             switch (baudSelector) {
                 case 0:

--- a/src/main/java/com/loomcom/symon/devices/Acia6551.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia6551.java
@@ -74,16 +74,16 @@ public class Acia6551 extends Acia {
     @Override
     public void write(int address, int data) throws MemoryAccessException {
         switch (address) {
-            case 0:
+            case DATA_REG:
                 txWrite(data);
                 break;
-            case 1:
+            case STAT_REG:
                 reset();
                 break;
-            case 2:
+            case CMND_REG:
                 setCommandRegister(data);
                 break;
-            case 3:
+            case CTRL_REG:
                 setControlRegister(data);
                 break;
             default:

--- a/src/main/java/com/loomcom/symon/devices/Acia6551.java
+++ b/src/main/java/com/loomcom/symon/devices/Acia6551.java
@@ -28,7 +28,7 @@ import com.loomcom.symon.exceptions.MemoryRangeException;
 
 /**
  * This is a simulation of the MOS 6551 ACIA, with limited
- * functionality.  Interrupts are not supported.
+ * functionality.
  * <p/>
  * Unlike a 16550 UART, the 6551 ACIA has only one-byte transmit and
  * receive buffers. It is the programmer's responsibility to check the


### PR DESCRIPTION
Fixes incorrect comments, and also uses named constants for registers when possible.